### PR TITLE
Change gt to gte when paging GraphQL results

### DIFF
--- a/apps/content-gateway-api/src/app/repository/MongoDataRepository.spec.ts
+++ b/apps/content-gateway-api/src/app/repository/MongoDataRepository.spec.ts
@@ -227,7 +227,7 @@ describe("Given a Mongo data storage", () => {
             expect(result).toEqual(
                 new GenericProgramError({
                     _tag: "SchemaValidationError",
-                    message: "Schema validation failed",
+                    message: `Schema validation failed`,
                     details: {
                         validationErrors: [
                             "must have required property 'name'",

--- a/libs/domain/feature-loaders/src/bankless-token/BanklessTokenAccountLoader.ts
+++ b/libs/domain/feature-loaders/src/bankless-token/BanklessTokenAccountLoader.ts
@@ -16,7 +16,7 @@ const QUERY: DocumentNode = gql`
         accounts(
             first: $limit
             orderBy: lastTransactionTimestamp
-            where: { lastTransactionTimestamp_gt: $cursor }
+            where: { lastTransactionTimestamp_gte: $cursor }
         ) {
             id
             ERC20balances {

--- a/libs/domain/feature-loaders/src/bankless-token/BanklessTokenTransactionLoader.ts
+++ b/libs/domain/feature-loaders/src/bankless-token/BanklessTokenTransactionLoader.ts
@@ -15,7 +15,7 @@ const QUERY: DocumentNode = gql`
         transactions(
             first: $limit
             orderBy: timestamp
-            where: { timestamp_gt: $cursor }
+            where: { timestamp_gte: $cursor }
         ) {
             id
             timestamp

--- a/libs/domain/feature-loaders/src/bankless-token/BanklessTokenTransferLoader.ts
+++ b/libs/domain/feature-loaders/src/bankless-token/BanklessTokenTransferLoader.ts
@@ -16,7 +16,7 @@ const QUERY: DocumentNode = gql`
         erc20Transfers(
             first: $limit
             orderBy: timestamp
-            where: { timestamp_gt: $cursor }
+            where: { timestamp_gte: $cursor }
         ) {
             id
             transaction {

--- a/libs/domain/feature-loaders/src/ens/ENSLoader.ts
+++ b/libs/domain/feature-loaders/src/ens/ENSLoader.ts
@@ -16,7 +16,7 @@ const QUERY: DocumentNode = gql`
         domains(
             first: $limit
             orderBy: createdAt
-            where: { createdAt_gt: $cursor }
+            where: { createdAt_gte: $cursor }
         ) {
             id
             name

--- a/libs/domain/feature-loaders/src/poap-token/POAPTokenLoader.ts
+++ b/libs/domain/feature-loaders/src/poap-token/POAPTokenLoader.ts
@@ -14,7 +14,7 @@ const QUERY: DocumentNode = gql`
         tokens(
             first: $limit
             orderBy: created
-            where: { created_gt: $cursor }
+            where: { created_gte: $cursor }
         ) {
             id
             created

--- a/libs/domain/feature-loaders/src/poap-token/POAPTransferLoader.ts
+++ b/libs/domain/feature-loaders/src/poap-token/POAPTransferLoader.ts
@@ -15,7 +15,7 @@ const QUERY: DocumentNode = gql`
         transfers(
             first: $limit
             orderBy: timestamp
-            where: { timestamp_gt: $cursor }
+            where: { timestamp_gte: $cursor }
         ) {
             id
             transaction


### PR DESCRIPTION
I've changed the GQL queries in the loaders to use `gte` instead of `gt`. This way we can't miss records, but we can theoretically end up in a situation where a loader gets stuck if there are at least `1000` records with the same timestamp. This would mean a 1000tx/s speed which I guess is unlikely at this time, but who knows what the future will bring...